### PR TITLE
Updates for OpenShift 4 (OCP4) Deployment

### DIFF
--- a/openshift/config.env
+++ b/openshift/config.env
@@ -6,9 +6,9 @@ FRONTEND_COMPONENT=frontend
 FRONTEND_PORT='8080'
 
 # Infrastructure
-NAMESPACE_TOOLS=
-NAMESPACE_DEPLOY=
-DOMAIN=pathfinder.gov.bc.ca
+NAMESPACE_TOOLS=245e18-tools
+NAMESPACE_DEPLOY=245e18-dev
+DOMAIN=apps.silver.devops.gov.bc.ca
 
 # Building
 DOCKER_SRC=docker-registry.default.svc:5000/openshift/nodejs:10

--- a/openshift/config.env
+++ b/openshift/config.env
@@ -1,5 +1,5 @@
 # Application
-APP=containerization-and-cloud-economic-model
+APP=cem
 BACKEND_COMPONENT=backend
 BACKEND_PORT='3000'
 FRONTEND_COMPONENT=frontend
@@ -11,6 +11,7 @@ NAMESPACE_DEPLOY=245e18-dev
 DOMAIN=apps.silver.devops.gov.bc.ca
 
 # Building
+#DOCKER_SRC=image-registry.apps.silver.devops.gov.bc.ca/openshift/nodejs:10
 DOCKER_SRC=docker-registry.default.svc:5000/openshift/nodejs:10
 BUILD_TAG=latest
 GIT_URL=https://github.com/ActionAnalytics/containerization-and-cloud-economic-model

--- a/openshift/config.env
+++ b/openshift/config.env
@@ -11,7 +11,6 @@ NAMESPACE_DEPLOY=245e18-dev
 DOMAIN=apps.silver.devops.gov.bc.ca
 
 # Building
-#DOCKER_SRC=image-registry.apps.silver.devops.gov.bc.ca/openshift/nodejs:10
-DOCKER_SRC=docker-registry.default.svc:5000/openshift/nodejs:10
+DOCKER_SRC=image-registry.openshift-image-registry.svc:5000/openshift/nodejs:10
 BUILD_TAG=latest
 GIT_URL=https://github.com/ActionAnalytics/containerization-and-cloud-economic-model

--- a/openshift/init.sh
+++ b/openshift/init.sh
@@ -14,7 +14,7 @@ else
 
   read -p "CLIENT_ID [CEM_SERVICE_CLIENT]:" CLIENT_ID
   CLIENT_ID="${CLIENT_ID:-CEM_SERVICE_CLIENT}"
-  read -p "CLIENT_SECRET:" CLIENT_SECRET
+  read -p "CLIENT_SECRET:" -s CLIENT_SECRET
   echo
   oc process -f ./templates/init.yml -p CLIENT_ID="${CLIENT_ID}" -p CLIENT_SECRET="${CLIENT_SECRET}" \
     --param-file=config.env | oc apply -f -

--- a/openshift/rollout.sh
+++ b/openshift/rollout.sh
@@ -2,7 +2,7 @@
 set -euo nounset
 
 # Vars (git branch, tools namespace)
-GIT_BRANCH="$(git symbolic-ref --short -q HEAD)"
+GIT_BRANCH="${GIT_BRANCH:-$(git symbolic-ref --short -q HEAD)}"
 source ./config.env
 
 # Initialize with secret, if necessary


### PR DESCRIPTION
Updates:
- ./openshift/config.env - APP, NAMESPACE_TOOLS, NAMESPACE_DEPLOY, DOMAIN and DOCKER_SRC
- ./openshift/rollout.sh - GIT_BRANCH override for testing from forks (still getting code from primary URL)

Note:
Aporetto requires some extra steps to configure network security policies.  Since this service is being discontinued code for it was not included.  The workaround is below.  The linked template may not hang around either.

```
LINK="https://raw.githubusercontent.com/BCDevOps/platform-services/master/security/aporeto/docs/sample/quickstart-nsp.yaml"
TOOLS_NAMESPACE="245e18-tools"
oc -n "${TOOLS_NAMESPACE}" process -p NAMESPACE="${TOOLS_NAMESPACE}" -f ${LINK} | oc -n "${TOOLS_NAMESPACE}" - apply -f -
```