### PR TITLE
package.json - update hosted-git-info for vulneratbility, dep of eslint-plugin-import

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -18,6 +18,7 @@
         "eslint-config-airbnb-base": "^14.2.1",
         "eslint-plugin-import": "^2.22.1",
         "eslint-plugin-vue": "^7.5.0",
+        "hosted-git-info": "^2.8.9",
         "nodemon": "^2.0.7"
       }
     },
@@ -1717,9 +1718,9 @@
       }
     },
     "node_modules/hosted-git-info": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
-      "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
       "dev": true
     },
     "node_modules/http-cache-semantics": {
@@ -5059,9 +5060,9 @@
       "dev": true
     },
     "hosted-git-info": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
-      "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
       "dev": true
     },
     "http-cache-semantics": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -23,6 +23,7 @@
     "eslint-config-airbnb-base": "^14.2.1",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-vue": "^7.5.0",
+    "hosted-git-info": "^2.8.9",
     "nodemon": "^2.0.7"
   },
   "dependencies": {


### PR DESCRIPTION
Copy/pasted from dependabot:
```
hosted-git-info
 Dismissed	DerekRoberts dismissed this alert 1 minute ago
 Dependabot cannot update hosted-git-info to a non-vulnerable version
The latest possible version of hosted-git-info that can be installed is 2.8.8.

The earliest fixed version is 2.8.9.

View logs or learn more about troubleshooting Dependabot errors.

1 hosted-git-info vulnerability found in backend/package-lock.json 2 days ago
Remediation
Upgrade hosted-git-info to version 2.8.9 or later. For example:

"dependencies": {
  "hosted-git-info": ">=2.8.9"
}
or…
"devDependencies": {
  "hosted-git-info": ">=2.8.9"
}
Always verify the validity and compatibility of suggestions with your codebase.

Details
CVE-2021-23362
moderate severity
Vulnerable versions: < 2.8.9
Patched version: 2.8.9
The npm package hosted-git-info before 3.0.8 are vulnerable to Regular Expression Denial of Service (ReDoS) via regular expression shortcutMatch in the fromUrl function in index.js. The affected regular expression exhibits polynomial worst-case time complexity
```