### PR TITLE
Minor updates: readme.md, phrasing.md and renaming master to main

### DIFF
--- a/PHRASING.md
+++ b/PHRASING.md
@@ -1,0 +1,34 @@
+<!-- From dependabot recommendations (e.g. https://github.com/bcgov/nr-ansible/issues/1) -->
+
+## TL;DR 🏎️
+
+Teams are encouraged to favour modern inclusive phrasing both in their communication as well as in any source checked into their repositories. You'll find a table at the end of this text with preferred phrasing to socialize with your team.
+
+## Words Matter
+
+We're aligning our development community to favour inclusive phrasing for common technical expressions. There is a table below that outlines the phrases that are being retired along with the preferred alternatives.
+
+During your team scrum, technical meetings, documentation, the code you write, etc. use the inclusive phrasing from the table below. That's it - it really is that easy.
+
+For the curious mind, the Public Service Agency (PSA) has published a guide describing how [Words Matter](https://www2.gov.bc.ca/assets/gov/careers/all-employees/working-with-others/words-matter.pdf) in our daily communication. Its an insightful read and a good reminder to be curious and open minded.
+
+## What about the master branch?
+
+The word "master" is not inherently bad or non-inclusive. For example people get a masters degree; become a master of their craft; or master a skill. It's generally when the word "master" is used along side the word "slave" that it becomes non-inclusive.
+
+Some teams choose to use the word `main` for the default branch of a repo as opposed to the more commonly used `master` branch. While it's not required or recommended, your team is empowered to do what works for them. If you do rename the `master` branch consider using `main` so that we have consistency among the repos within our organization. 
+
+## Preferred Phrasing
+
+| Non-Inclusive  |    | Inclusive |
+| :------------- |:--:| :-------- |
+| Whitelist      | => | Allowlist |
+| Blacklist      | => | Denylist |
+| Master / Slave | => | Leader / Follower; Primary / Standby; etc |
+| Grandfathered  | => | Legacy status |
+| Sanity check   | => | Quick check; Confidence check; etc |
+| Dummy value    | => | Placeholder value; Sample value; etc |
+
+### Pro Tip 🤓
+
+This list is not comprehensive. If you're aware of other outdated nomenclature please create an issue (PR preferred) with your suggestion.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 <!-- PROJECT SHIELDS -->
 
-[![Contributors](https://img.shields.io/github/contributors/bcgov/containerization-and-cloud-economic-model.svg?style=for-the-badge)](/../../graphs/contributors)
-[![Forks](https://img.shields.io/github/forks/bcgov/containerization-and-cloud-economic-model.svg?style=for-the-badge)](/../../network/members)
-[![Stargazers](https://img.shields.io/github/stars/bcgov/containerization-and-cloud-economic-model.svg?style=for-the-badge)](/../../stargazers)
-[![Issues](https://img.shields.io/github/issues/bcgov/containerization-and-cloud-economic-model.svg?style=for-the-badge)](/../../issues)
-[![MIT License](https://img.shields.io/github/license/bcgov/containerization-and-cloud-economic-model.svg?style=for-the-badge)](/LICENSE.txt)
-[![Lifecycle](https://img.shields.io/badge/Lifecycle-Stable-97ca00?style=for-the-badge)](https://github.com/bcgov/repomountie/blob/master/doc/lifecycle-badges.md)
+[![Contributors](https://img.shields.io/github/contributors/bcgov/containerization-and-cloud-economic-model.svg)](/../../graphs/contributors)
+[![Forks](https://img.shields.io/github/forks/bcgov/containerization-and-cloud-economic-model.svg)](/../../network/members)
+[![Stargazers](https://img.shields.io/github/stars/bcgov/containerization-and-cloud-economic-model.svg)](/../../stargazers)
+[![Issues](https://img.shields.io/github/issues/bcgov/containerization-and-cloud-economic-model.svg)](/../../issues)
+[![MIT License](https://img.shields.io/github/license/bcgov/containerization-and-cloud-economic-model.svg)](/LICENSE.txt)
+[![Lifecycle](https://img.shields.io/badge/Lifecycle-Stable-97ca00)](https://github.com/bcgov/repomountie/blob/master/doc/lifecycle-badges.md)
 
 
 <!-- PROJECT LOGO -->

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 <!-- PROJECT SHIELDS -->
 
-[![Contributors](https://img.shields.io/github/contributors/ActionAnalytics/containerization-and-cloud-economic-model.svg?style=for-the-badge)](/../../graphs/contributors)
-[![Forks](https://img.shields.io/github/forks/ActionAnalytics/containerization-and-cloud-economic-model.svg?style=for-the-badge)](/../../network/members)
-[![Stargazers](https://img.shields.io/github/stars/ActionAnalytics/containerization-and-cloud-economic-model.svg?style=for-the-badge)](/../../stargazers)
-[![Issues](https://img.shields.io/github/issues/ActionAnalytics/containerization-and-cloud-economic-model.svg?style=for-the-badge)](/../../issues)
-[![MIT License](https://img.shields.io/github/license/ActionAnalytics/containerization-and-cloud-economic-model.svg?style=for-the-badge)](/LICENSE.txt)
+[![Contributors](https://img.shields.io/github/contributors/bcgov/containerization-and-cloud-economic-model.svg?style=for-the-badge)](/../../graphs/contributors)
+[![Forks](https://img.shields.io/github/forks/bcgov/containerization-and-cloud-economic-model.svg?style=for-the-badge)](/../../network/members)
+[![Stargazers](https://img.shields.io/github/stars/bcgov/containerization-and-cloud-economic-model.svg?style=for-the-badge)](/../../stargazers)
+[![Issues](https://img.shields.io/github/issues/bcgov/containerization-and-cloud-economic-model.svg?style=for-the-badge)](/../../issues)
+[![MIT License](https://img.shields.io/github/license/bcgov/containerization-and-cloud-economic-model.svg?style=for-the-badge)](/LICENSE.txt)
 [![Lifecycle](https://img.shields.io/badge/Lifecycle-Stable-97ca00?style=for-the-badge)](https://github.com/bcgov/repomountie/blob/master/doc/lifecycle-badges.md)
 
 


### PR DESCRIPTION
Small batch of documentation and branch changes.

### Summary

Documentation:

- Added PHRASING.md, as recommended by dependabot
- Updated links in README.md, which worked, but had been redirecting from ActionAnalytics org
- Removed README badge styling, which looks nice, but has added complication

### Note

The following happened outside of this PR, but were spurred by it:

- Replaced master with main branch
- Updated default branch
- Updated branch protection rules accordingly